### PR TITLE
fix iter bug

### DIFF
--- a/util/extract_feature_v1.py
+++ b/util/extract_feature_v1.py
@@ -65,8 +65,9 @@ def extract_feature(data_root, backbone, model_root, input_size = [112, 112], rg
     idx = 0
     features = np.zeros([len(loader.dataset), embedding_size])
     with torch.no_grad():
+        iter_loader = iter(loader)
         while idx + batch_size <= len(loader.dataset):
-            batch, _ = iter(loader).next()
+            batch, _ = iter_loader.next()
             if tta:
                 fliped = hflip_batch(batch)
                 emb_batch = backbone(batch.to(device)).cpu() + backbone(fliped.to(device)).cpu()
@@ -76,7 +77,7 @@ def extract_feature(data_root, backbone, model_root, input_size = [112, 112], rg
             idx += batch_size
 
         if idx < len(loader.dataset):
-            batch, _ = iter(loader).next()
+            batch, _ = iter_loader.next()
             if tta:
                 fliped = hflip_batch(batch)
                 emb_batch = backbone(batch.to(device)).cpu() + backbone(fliped.to(device)).cpu()


### PR DESCRIPTION
It will always iter the first batch if we do like this.
```
        while idx + batch_size <= len(loader.dataset):
            batch, _ = iter(loader).next()
```
Maybe we should execute `iter(loader)` outside the while loop.