### PR TITLE
fix: numpy 1.16.3+ compatible

### DIFF
--- a/align/get_nets.py
+++ b/align/get_nets.py
@@ -52,7 +52,7 @@ class PNet(nn.Module):
         self.conv4_1 = nn.Conv2d(32, 2, 1, 1)
         self.conv4_2 = nn.Conv2d(32, 4, 1, 1)
 
-        weights = np.load("./pnet.npy")[()]
+        weights = np.load("./pnet.npy", allow_pickle=True)[()]
         for n, p in self.named_parameters():
             p.data = torch.FloatTensor(weights[n])
 
@@ -97,7 +97,7 @@ class RNet(nn.Module):
         self.conv5_1 = nn.Linear(128, 2)
         self.conv5_2 = nn.Linear(128, 4)
 
-        weights = np.load("./rnet.npy")[()]
+        weights = np.load("./rnet.npy", allow_pickle=True)[()]
         for n, p in self.named_parameters():
             p.data = torch.FloatTensor(weights[n])
 
@@ -148,7 +148,7 @@ class ONet(nn.Module):
         self.conv6_2 = nn.Linear(256, 4)
         self.conv6_3 = nn.Linear(256, 10)
 
-        weights = np.load("./onet.npy")[()]
+        weights = np.load("./onet.npy", allow_pickle=True)[()]
         for n, p in self.named_parameters():
             p.data = torch.FloatTensor(weights[n])
 


### PR DESCRIPTION
np.load changed allow_pickle to false as default in response to CVE-2019-6446 (this commit make get_nets.py compatible)